### PR TITLE
Fixing RN handler

### DIFF
--- a/src/handlers/ReactNativeUnifiedPlan.ts
+++ b/src/handlers/ReactNativeUnifiedPlan.ts
@@ -386,12 +386,6 @@ export class ReactNativeUnifiedPlan extends HandlerInterface
 
 		await this._pc.setLocalDescription(offer);
 
-		// We can now get the transceiver.mid.
-		const localId = transceiver.mid;
-
-		// Set MID.
-		sendingRtpParameters.mid = localId;
-
 		localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
 		offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
 
@@ -474,6 +468,10 @@ export class ReactNativeUnifiedPlan extends HandlerInterface
 			answer);
 
 		await this._pc.setRemoteDescription(answer);
+
+		// We can now get the transceiver.mid. That is only possible after the negotiation is completed
+		// More details here: https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver/mid
+		const localId = transceiver.mid;
 
 		// Store in the map.
 		this._mapMidTransceiver.set(localId, transceiver);

--- a/src/handlers/ReactNativeUnifiedPlan.ts
+++ b/src/handlers/ReactNativeUnifiedPlan.ts
@@ -20,11 +20,7 @@ import {
 import { RemoteSdp } from './sdp/RemoteSdp';
 import { parse as parseScalabilityMode } from '../scalabilityModes';
 import { IceParameters, DtlsRole } from '../Transport';
-import {
-	RtpCapabilities,
-	RtpParameters,
-	RtpEncodingParameters
-} from '../RtpParameters';
+import { RtpCapabilities, RtpParameters } from '../RtpParameters';
 import { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
 
 const logger = new Logger('ReactNativeUnifiedPlan');
@@ -309,14 +305,6 @@ export class ReactNativeUnifiedPlan extends HandlerInterface
 
 		logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
 
-		if (encodings && encodings.length > 1)
-		{
-			encodings.forEach((encoding: RtpEncodingParameters, idx: number) =>
-			{
-				encoding.rid = `r${idx}`;
-			});
-		}
-
 		const sendingRtpParameters =
 			utils.clone(this._sendingRtpParametersByKind![track.kind], {});
 
@@ -333,12 +321,7 @@ export class ReactNativeUnifiedPlan extends HandlerInterface
 
 		const mediaSectionIdx = this._remoteSdp!.getNextMediaSectionIdx();
 		const transceiver = this._pc.addTransceiver(
-			track,
-			{
-				direction     : 'sendonly',
-				streams       : [ this._sendStream ],
-				sendEncodings : encodings
-			});
+			track, { direction: 'sendonly', streams: [ this._sendStream ] });
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
 		let offerMediaObject;
@@ -352,29 +335,20 @@ export class ReactNativeUnifiedPlan extends HandlerInterface
 				});
 		}
 
-		// Special case for VP9 with SVC.
-		let hackVp9Svc = false;
-
 		const layers =
 			parseScalabilityMode((encodings || [ {} ])[0].scalabilityMode);
 
-		if (
-			encodings &&
-			encodings.length === 1 &&
-			layers.spatialLayers > 1 &&
-			sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp9'
-		)
+		if (encodings && encodings.length > 1)
 		{
-			logger.debug('send() | enabling legacy simulcast for VP9 SVC');
+			logger.debug('send() | enabling legacy simulcast');
 
-			hackVp9Svc = true;
 			localSdpObject = sdpTransform.parse(offer.sdp);
 			offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
 
 			sdpUnifiedPlanUtils.addLegacySimulcast(
 				{
 					offerMediaObject,
-					numStreams : layers.spatialLayers
+					numStreams : encodings.length
 				});
 
 			offer = { type: 'offer', sdp: sdpTransform.write(localSdpObject) };
@@ -399,31 +373,18 @@ export class ReactNativeUnifiedPlan extends HandlerInterface
 		sendingRtpParameters.rtcp.cname =
 			sdpCommonUtils.getCname({ offerMediaObject });
 
-		// Set RTP encodings by parsing the SDP offer if no encodings are given.
-		if (!encodings)
-		{
-			sendingRtpParameters.encodings =
-				sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
-		}
-		// Set RTP encodings by parsing the SDP offer and complete them with given
-		// one if just a single encoding has been given.
-		else if (encodings.length === 1)
-		{
-			let newEncodings =
-				sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
+		// Set RTP encodings.
+		sendingRtpParameters.encodings =
+			sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
 
-			Object.assign(newEncodings[0], encodings[0]);
-
-			// Hack for VP9 SVC.
-			if (hackVp9Svc)
-				newEncodings = [ newEncodings[0] ];
-
-			sendingRtpParameters.encodings = newEncodings;
-		}
-		// Otherwise if more than 1 encoding are given use them verbatim.
-		else
+		// Complete encodings with given values.
+		if (encodings)
 		{
-			sendingRtpParameters.encodings = encodings;
+			for (let idx = 0; idx < sendingRtpParameters.encodings.length; ++idx)
+			{
+				if (encodings[idx])
+					Object.assign(sendingRtpParameters.encodings[idx], encodings[idx]);
+			}
 		}
 
 		// If VP8 or H264 and there is effective simulcast, add scalabilityMode to

--- a/src/handlers/ReactNativeUnifiedPlan.ts
+++ b/src/handlers/ReactNativeUnifiedPlan.ts
@@ -20,7 +20,11 @@ import {
 import { RemoteSdp } from './sdp/RemoteSdp';
 import { parse as parseScalabilityMode } from '../scalabilityModes';
 import { IceParameters, DtlsRole } from '../Transport';
-import { RtpCapabilities, RtpParameters } from '../RtpParameters';
+import {
+	RtpCapabilities,
+	RtpParameters,
+	RtpEncodingParameters
+} from '../RtpParameters';
 import { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
 
 const logger = new Logger('ReactNativeUnifiedPlan');
@@ -305,6 +309,23 @@ export class ReactNativeUnifiedPlan extends HandlerInterface
 
 		logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
 
+		// Mediasoup currently has no dependency on React Native.
+		// And this is supposed to be a temporary fix, until the Mediasoup bug is fixed.
+		// Opened issue, Unable to send video from iOS:
+		// https://github.com/versatica/mediasoup-client/issues/251
+		// @ts-ignore
+		const isIOS = window?.DailyNativeUtils?.platform?.OS === 'ios';
+
+		logger.debug('isIOS', isIOS);
+
+		if (!isIOS && encodings && encodings.length > 1)
+		{
+			encodings.forEach((encoding: RtpEncodingParameters, idx: number) =>
+			{
+				encoding.rid = `r${idx}`;
+			});
+		}
+
 		const sendingRtpParameters =
 			utils.clone(this._sendingRtpParametersByKind![track.kind], {});
 
@@ -321,7 +342,12 @@ export class ReactNativeUnifiedPlan extends HandlerInterface
 
 		const mediaSectionIdx = this._remoteSdp!.getNextMediaSectionIdx();
 		const transceiver = this._pc.addTransceiver(
-			track, { direction: 'sendonly', streams: [ this._sendStream ] });
+			track,
+			{
+				direction     : 'sendonly',
+				streams       : [ this._sendStream ],
+				sendEncodings : !isIOS ? encodings : undefined
+			});
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
 		let offerMediaObject;
@@ -338,7 +364,7 @@ export class ReactNativeUnifiedPlan extends HandlerInterface
 		const layers =
 			parseScalabilityMode((encodings || [ {} ])[0].scalabilityMode);
 
-		if (encodings && encodings.length > 1)
+		if (isIOS && encodings && encodings.length > 1)
 		{
 			logger.debug('send() | enabling legacy simulcast');
 
@@ -373,17 +399,38 @@ export class ReactNativeUnifiedPlan extends HandlerInterface
 		sendingRtpParameters.rtcp.cname =
 			sdpCommonUtils.getCname({ offerMediaObject });
 
-		// Set RTP encodings.
-		sendingRtpParameters.encodings =
-			sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
-
-		// Complete encodings with given values.
-		if (encodings)
+		// Set RTP encodings by parsing the SDP offer if no encodings are given.
+		if (!encodings)
 		{
-			for (let idx = 0; idx < sendingRtpParameters.encodings.length; ++idx)
+			sendingRtpParameters.encodings =
+				sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
+		}
+		// Set RTP encodings by parsing the SDP offer and complete them with given
+		// one if just a single encoding has been given.
+		else if (encodings.length === 1)
+		{
+			let newEncodings =
+				sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
+
+			Object.assign(newEncodings[0], encodings[0]);
+
+			sendingRtpParameters.encodings = newEncodings;
+		}
+		// Otherwise if more than 1 encoding are given use them verbatim.
+		else
+		{
+			if (isIOS)
 			{
-				if (encodings[idx])
-					Object.assign(sendingRtpParameters.encodings[idx], encodings[idx]);
+				sendingRtpParameters.encodings =
+					sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
+				for (let idx = 0; idx < sendingRtpParameters.encodings.length; ++idx)
+				{
+					if (encodings[idx])
+						Object.assign(sendingRtpParameters.encodings[idx], encodings[idx]);
+				}
+			}
+			else {
+				sendingRtpParameters.encodings = encodings;
 			}
 		}
 


### PR DESCRIPTION

- Fixing to be able to send more than one video from RN.

They are currently trying to use the mid when the negotiation is not completed yet. 

In this case, they are receiving null as the mid value, instead of the value itself. When we try to send a second video track, for instance the video from getDisplayMedia, we stop to send the first one. 

More details about mid: https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver/mid

- Fixing to be able to send video from iOS when using encodings, which we basically do for the simulcast.

In order to make It work, we are changing the `ReactNativeUnifiedPlan` handler to behave in a similar way as the Safari12 handler. More details [here](https://github.com/versatica/mediasoup-client/blob/8f80c6a853bba2801f102c9d8d276a08aa8ad297/src/handlers/Safari12.ts#L292).

The idea is to submit this same PR to the mediasoup-client upstream, so we can keep using the official version of the library.